### PR TITLE
DSL Classes

### DIFF
--- a/lib/porridge.rb
+++ b/lib/porridge.rb
@@ -18,6 +18,8 @@ require_relative 'porridge/field_serializer'
 require_relative 'porridge/serializing_extractor'
 require_relative 'porridge/whitelist_field_policy'
 require_relative 'porridge/factory'
+require_relative 'porridge/serializer_definer'
+require_relative 'porridge/serializer_definition'
 
 # {Porridge} is the root namespace for all classes in the +porridge+ gem.
 module Porridge; end

--- a/lib/porridge.rb
+++ b/lib/porridge.rb
@@ -17,6 +17,7 @@ require_relative 'porridge/field_policy'
 require_relative 'porridge/field_serializer'
 require_relative 'porridge/serializing_extractor'
 require_relative 'porridge/whitelist_field_policy'
+require_relative 'porridge/factory'
 
 # {Porridge} is the root namespace for all classes in the +porridge+ gem.
 module Porridge; end

--- a/lib/porridge/factory.rb
+++ b/lib/porridge/factory.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Porridge
+  # {Factory} is a class that is capable of instantiating various porridge serializers and extractors. All extractor-
+  # creation methods are suffixed with +_extractor+, all serializer-creation methods are suffixed with +_serializer+,
+  # and all field serializer-creation methods are suffixed with +_field_serializer+.
+  #
+  # You may subclass this class if you wish to change its behavior. For example, if you wished to substitute your
+  # own "from name" extractor, that accesses a hash value rather than sends a method call, for the default one:
+  #
+  #   class CustomPorridgeFactory < Porridge::Factory
+  #     def from_name_extractor(name)
+  #       extractor HashValueExtractor.new(name)
+  #     end
+  #   end
+  #
+  # {#from_name_field_serializer}, {#attribute_extractor}, and {#attribute_field_serializer} would then be automatically
+  # updated in the process, along with any other methods that depend on the aforementioned ones.
+  #
+  # This method is rarely used directly. Typically, it is used in conjunction with a {SerializerDefiner} and/or
+  # {SerializerDefinition} instance.
+  class Factory
+    def extractor(base)
+      return nil if base.nil?
+
+      Extractor.ensure_valid!(base)
+      base
+    end
+
+    def from_name_extractor(name)
+      extractor SendExtractor.new(name)
+    end
+
+    def custom_extractor(callback)
+      extractor callback
+    end
+
+    def association_extractor(serializer:, extractor: nil, extraction_name: nil, callback: nil, &block)
+      extractor SerializingExtractor.new(
+        extractor || custom_extractor(callback) || custom_extractor(block) || from_name_extractor(extraction_name),
+        serializer
+      )
+    end
+    alias belongs_to_extractor association_extractor
+    alias has_many_extractor association_extractor
+
+    def serializer(base)
+      return nil if base.nil?
+
+      Serializer.ensure_valid!(base)
+      base
+    end
+
+    def chain_serializer(*bases)
+      serializer ChainSerializer.new(*bases)
+    end
+    alias serializers chain_serializer
+
+    def for_extracted_serializer(serializer, extractor)
+      serializer SerializerForExtracted.new(serializer, extractor)
+    end
+    alias serializer_for_extracted for_extracted_serializer
+
+    def field_serializer(name, extractor)
+      serializer FieldSerializer.new(name, extractor)
+    end
+
+    def attribute_field_serializer(name, callback = nil, extraction_name: nil, &block)
+      extractor = custom_extractor(callback || block) || from_name_extractor(extraction_name || name)
+      field_serializer(name, extractor)
+    end
+
+    def association_field_serializer(name, options = {}, &block)
+      options[:extraction_name] ||= name
+      field_serializer(name, association_extractor(**options, &block))
+    end
+    alias belongs_to_field_serializer association_field_serializer
+    alias has_many_field_serializer association_field_serializer
+  end
+end

--- a/lib/porridge/serializer_definer.rb
+++ b/lib/porridge/serializer_definer.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Porridge
+  # {SerializerDefiner} is a class that wraps a {Factory} and allows serializes to be easily defined with an elegant
+  # DSL.
+  class SerializerDefiner
+    FACTORY_PREFIX = 'create_'
+    SERIALIZER_SUFFIX = '_serializer'
+    FIELD_SERIALIZER_SUFFIX = '_field_serializer'
+
+    delegate :call, to: :defined_serializer
+
+    def initialize(factory = Factory.new)
+      @factory = factory
+      @serializers = []
+    end
+
+    def method_missing(method_name, *args, &block)
+      method_name = method_name.to_s
+      return factory.send(method_name.delete_prefix(FACTORY_PREFIX), *args, &block) if create_method? method_name
+
+      if serializer_method? method_name
+        return add_serializer(factory.send(method_name + SERIALIZER_SUFFIX, *args, &block))
+      end
+
+      if field_serializer_method? method_name
+        return add_serializer(factory.send(method_name + FIELD_SERIALIZER_SUFFIX, *args, &block))
+      end
+
+      super(method_name.to_sym, *args, &block)
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      method_name = method_name.to_s
+      super(method_name.to_sym, include_private) ||
+        create_method?(method_name) ||
+        serializer_method?(method_name) ||
+        field_serializer_method?(method_name)
+    end
+
+    def defined_serializer
+      factory.serializers(*added_serializers)
+    end
+
+    def added_serializers
+      @serializers
+    end
+
+    def serializer(...)
+      add_serializer(factory.serializer(...))
+    end
+
+    private
+
+    def create_method?(method_name)
+      method_name.start_with?(FACTORY_PREFIX) && factory.respond_to?(method_name.delete_prefix(FACTORY_PREFIX))
+    end
+
+    def serializer_method?(method_name)
+      factory.respond_to?(method_name + SERIALIZER_SUFFIX)
+    end
+
+    def field_serializer_method?(method_name)
+      factory.respond_to?(method_name + FIELD_SERIALIZER_SUFFIX)
+    end
+
+    def add_serializer(serializer)
+      @serializers << serializer
+    end
+
+    attr_reader :factory
+  end
+end

--- a/lib/porridge/serializer_definition.rb
+++ b/lib/porridge/serializer_definition.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Porridge
+  # {SerializerDefinition} is a class that allows serializers to be defined as with a {SerializerDefiner}, but within
+  # a class. Simply subclass this class and use the same DSL within it.
+  class SerializerDefinition
+    class << self
+      attr_writer :definer
+
+      delegate_missing_to :definer
+
+      def inherited(subclass)
+        super
+        definer.added_serializers.each { |serializer| subclass.definer.serializer(serializer) }
+      end
+
+      def definer
+        @definer ||= create_definer
+      end
+
+      def create_definer
+        SerializerDefiner.new
+      end
+
+      def reset!
+        @definer = nil
+      end
+    end
+  end
+end

--- a/spec/porridge/factory_spec.rb
+++ b/spec/porridge/factory_spec.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Porridge::Factory do
+  let(:instance) { described_class.new }
+
+  describe '#extractor' do
+    context 'when given a valid extractor' do
+      let(:extractor) { Porridge::Extractor.new }
+      let(:result) { instance.extractor(extractor) }
+
+      it 'returns the extractor' do
+        expect(result).to eq extractor
+      end
+    end
+
+    context 'when given an invalid extractor' do
+      let(:extractor) { Object.new }
+      let(:result) { instance.extractor(extractor) }
+
+      it 'raises an appropriate error' do
+        expect { result }.to raise_error Porridge::InvalidExtractorError
+      end
+    end
+
+    context 'when given a nil extractor' do
+      let(:extractor) { nil }
+      let(:result) { instance.extractor(extractor) }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe '#from_name_extractor' do
+    let(:result) { instance.from_name_extractor(:length) }
+
+    it 'returns an extractor that sends a method to the object' do
+      expect(result.call('aaaa', {})).to eq 4
+    end
+  end
+
+  describe '#custom_extractor' do
+    let(:result) { instance.custom_extractor(proc { |obj| obj.reverse }) }
+
+    it 'returns an extractor that calls the callback' do
+      expect(result.call('abc', {})).to eq 'cba'
+    end
+  end
+
+  shared_examples_for '#association_extractor' do
+    let(:serializer) { proc { |obj| obj } }
+
+    context 'with explicit extractor' do
+      let(:extractor) { proc { |obj| obj[:association] } }
+      let(:result) { execute(serializer: serializer, extractor: extractor) }
+
+      it 'returns an extractor that uses the explicit extractor' do
+        expect(result.call({ association: 'value' }, {})).to eq 'value'
+      end
+    end
+
+    context 'with extraction name' do
+      let(:result) { execute(serializer: serializer, extraction_name: :reverse) }
+
+      it 'returns an extractor that sends a method to the object' do
+        expect(result.call('abc', {})).to eq 'cba'
+      end
+    end
+
+    context 'with callback' do
+      let(:callback) { proc { |obj| obj * 10 } }
+      let(:result) { execute(serializer: serializer, callback: callback) }
+
+      it 'returns an extractor that calls the callback' do
+        expect(result.call(50, {})).to eq 500
+      end
+    end
+
+    context 'with block' do
+      let(:result) { execute(serializer: serializer) { |obj| obj * 5 } }
+
+      it 'returns an extractor that calls the callback' do
+        expect(result.call('a', {})).to eq 'aaaaa'
+      end
+    end
+  end
+
+  describe '#association_extractor' do
+    def execute(...)
+      instance.association_extractor(...)
+    end
+
+    it_behaves_like '#association_extractor'
+  end
+
+  describe '#belongs_to_extractor' do
+    def execute(...)
+      instance.belongs_to_extractor(...)
+    end
+
+    it_behaves_like '#association_extractor'
+  end
+
+  describe '#has_many_extractor' do
+    def execute(...)
+      instance.has_many_extractor(...)
+    end
+
+    it_behaves_like '#association_extractor'
+  end
+
+  describe '#serializer' do
+    context 'when given a valid serializer' do
+      let(:serializer) { Porridge::Serializer.new }
+      let(:result) { instance.serializer(serializer) }
+
+      it 'returns the serializer' do
+        expect(result).to eq serializer
+      end
+    end
+
+    context 'when given an invalid serializer' do
+      let(:serializer) { Object.new }
+      let(:result) { instance.serializer(serializer) }
+
+      it 'raises an appropriate error' do
+        expect { result }.to raise_error Porridge::InvalidSerializerError
+      end
+    end
+
+    context 'when given a nil serializer' do
+      let(:serializer) { nil }
+      let(:result) { instance.serializer(serializer) }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    shared_examples_for '#chain_serializer' do
+      let(:serializers) do
+        [
+          proc { |_obj, hash|
+            hash[:one] = 1
+            hash
+          },
+          proc { |_obj, hash|
+            hash[:two] = 2
+            hash
+          },
+          proc { |_obj, hash|
+            hash[:three] = 3
+            hash
+          }
+        ]
+      end
+      let(:result) { execute(serializers) }
+
+      it 'returns a serializer that chains the given ones' do
+        expect(result.call(Object.new, { zero: 0 }, {})).to eq({
+          zero: 0,
+          one: 1,
+          two: 2,
+          three: 3
+        })
+      end
+    end
+
+    describe '#chain_serializer' do
+      def execute(serializers)
+        instance.chain_serializer(*serializers)
+      end
+
+      it_behaves_like '#chain_serializer'
+    end
+
+    describe '#serializers' do
+      def execute(serializers)
+        instance.serializers(*serializers)
+      end
+
+      it_behaves_like '#chain_serializer'
+    end
+
+    shared_examples_for '#for_extracted_serializer' do
+      let(:serializer) { proc { |obj| "#{obj}_serialized" } }
+      let(:extractor) { proc { |obj| "#{obj}_extracted" } }
+      let(:result) { execute(serializer, extractor) }
+
+      it 'returns a serializer that serializes the extracted value' do
+        expect(result.call('input', {}, {})).to eq 'input_extracted_serialized'
+      end
+    end
+
+    describe '#for_extracted_serializer' do
+      def execute(serializer, extractor)
+        instance.for_extracted_serializer(serializer, extractor)
+      end
+
+      it_behaves_like '#for_extracted_serializer'
+    end
+
+    describe '#serializer_for_extracted' do
+      def execute(serializer, extractor)
+        instance.serializer_for_extracted(serializer, extractor)
+      end
+
+      it_behaves_like '#for_extracted_serializer'
+    end
+
+    describe '#field_serializer' do
+      let(:extractor) { proc { |obj| "#{obj}_extracted" } }
+      let(:result) { instance.field_serializer(:key, extractor) }
+
+      it 'returns a serializer that adds a field' do
+        expect(result.call('input', {}, field_policy: Porridge::FieldPolicy.new)).to eq({ key: 'input_extracted' })
+      end
+    end
+
+    describe '#attribute_field_serializer' do
+      context 'when given only name' do
+        let(:result) { instance.attribute_field_serializer(:length) }
+
+        it 'returns a serializer that adds a field via sending a method to the object' do
+          expect(result.call('abcde', {}, field_policy: Porridge::FieldPolicy.new)).to eq({ length: 5 })
+        end
+      end
+
+      context 'when given a name and an extraction name' do
+        let(:result) { instance.attribute_field_serializer(:bigness, extraction_name: :length) }
+
+        it 'returns a serializer that adds a field via sending the extraction name to the object' do
+          expect(result.call('abcd', {}, field_policy: Porridge::FieldPolicy.new)).to eq({ bigness: 4 })
+        end
+      end
+
+      context 'when given a name and a callback' do
+        let(:result) { instance.attribute_field_serializer(:reversed, proc { |obj| obj.reverse }) }
+
+        it 'returns a serializer that adds a field via calling the callback' do
+          expect(result.call('abc', {}, field_policy: Porridge::FieldPolicy.new)).to eq({ reversed: 'cba' })
+        end
+      end
+
+      context 'when given a name and a block' do
+        let(:result) { instance.attribute_field_serializer(:reversed) { |obj, _opts| obj.reverse } }
+
+        it 'returns a serializer that adds a field via calling the block' do
+          expect(result.call('abc', {}, field_policy: Porridge::FieldPolicy.new)).to eq({ reversed: 'cba' })
+        end
+      end
+    end
+
+    shared_examples_for '#association_field_serializer' do
+      context 'when given only a name and a serializer' do
+        let(:serializer) { proc { |obj| obj } }
+        let(:result) { execute(:associated, serializer: serializer) }
+        let(:object) { Struct.new(:associated).new('input object') }
+
+        it 'returns a serializer that adds a field via serializing the result of calling the method' do
+          expect(result.call(object, {}, field_policy: Porridge::FieldPolicy.new)).to eq(associated: 'input object')
+        end
+      end
+
+      context 'when a name, an extraction name, and a serializer' do
+        let(:serializer) { proc { |obj| obj } }
+        let(:result) { execute(:association, extraction_name: :associated, serializer: serializer) }
+        let(:object) { Struct.new(:associated).new('input object') }
+
+        it 'returns a serializer that adds a field via serializing the result of calling the method' do
+          expect(result.call(object, {}, field_policy: Porridge::FieldPolicy.new)).to eq(association: 'input object')
+        end
+      end
+    end
+
+    describe '#association_field_serializer' do
+      def execute(...)
+        instance.association_field_serializer(...)
+      end
+
+      it_behaves_like '#association_field_serializer'
+    end
+
+    describe '#belongs_to_field_serializer' do
+      def execute(...)
+        instance.belongs_to_field_serializer(...)
+      end
+
+      it_behaves_like '#association_field_serializer'
+    end
+
+    describe '#has_many_field_serializer' do
+      def execute(...)
+        instance.has_many_field_serializer(...)
+      end
+
+      it_behaves_like '#association_field_serializer'
+    end
+  end
+end

--- a/spec/porridge/serializer_definer_spec.rb
+++ b/spec/porridge/serializer_definer_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Porridge::SerializerDefiner do
+  let(:instance) { described_class.new }
+
+  it_behaves_like 'SerializerDefiner'
+end

--- a/spec/porridge/serializer_definition_spec.rb
+++ b/spec/porridge/serializer_definition_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+class EmptyDerivedDefinition < Porridge::SerializerDefinition; end
+
+class DerivedDefinition < Porridge::SerializerDefinition
+  attribute :id
+  attribute :name
+end
+
+class DeeplyDerivedDefinition < DerivedDefinition
+  attribute :email
+end
+
+describe Porridge::SerializerDefinition do
+  let(:instance) { described_class }
+
+  before { described_class.reset! }
+
+  it_behaves_like 'SerializerDefiner'
+
+  context 'when derived' do
+    let(:instance) { EmptyDerivedDefinition }
+
+    before { EmptyDerivedDefinition.reset! }
+
+    it_behaves_like 'SerializerDefiner'
+  end
+
+  context 'when derived and modified' do
+    let(:instance) { DerivedDefinition }
+
+    it 'does not change the superclass' do
+      expect(described_class.definer.added_serializers).to be_empty
+    end
+  end
+
+  context 'when derived from with serializers and modified' do
+    let(:instance) { DeeplyDerivedDefinition }
+
+    it 'inherits the serializers' do
+      expect(instance.definer.added_serializers.count).to eq 3
+    end
+
+    it 'does not change the superclasses', :aggregate_failures do
+      expect(described_class.definer.added_serializers).to be_empty
+      expect(DerivedDefinition.definer.added_serializers.count).to eq 2
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require 'porridge'
 require_relative 'support/shared_examples/method_requiring_valid_serializer'
 require_relative 'support/shared_examples/method_requiring_valid_extractor'
 require_relative 'support/shared_examples/method_requiring_valid_field_policy'
+require_relative 'support/shared_examples/serializer_definer'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/shared_examples/serializer_definer.rb
+++ b/spec/support/shared_examples/serializer_definer.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_examples_for 'SerializerDefiner' do
+  context 'when a nonexistent method is called' do
+    it 'raises an appropriate error' do
+      expect { instance.nonexistent }.to raise_error NoMethodError
+    end
+  end
+
+  describe 'create_* methods' do
+    it 'responds to the same ones as Factory', :aggregate_failures do
+      expect(instance).to respond_to(:create_from_name_extractor)
+      expect(instance).to respond_to(:create_custom_extractor)
+      expect(instance).to respond_to(:create_association_extractor)
+      expect(instance).to respond_to(:create_belongs_to_extractor)
+      expect(instance).to respond_to(:create_has_many_extractor)
+      expect(instance).to respond_to(:create_serializer)
+      expect(instance).to respond_to(:create_chain_serializer)
+      expect(instance).to respond_to(:create_serializers)
+      expect(instance).to respond_to(:create_for_extracted_serializer)
+      expect(instance).to respond_to(:create_serializer_for_extracted)
+      expect(instance).to respond_to(:create_field_serializer)
+      expect(instance).to respond_to(:create_attribute_field_serializer)
+      expect(instance).to respond_to(:create_association_field_serializer)
+      expect(instance).to respond_to(:create_belongs_to_field_serializer)
+      expect(instance).to respond_to(:create_has_many_field_serializer)
+    end
+
+    it 'does not respond to invalid create_* methods' do
+      expect(instance).not_to respond_to(:create_nonexistent)
+    end
+
+    it 'delegates correctly' do
+      expect(instance.create_attribute_field_serializer(:name)).to be_a Porridge::FieldSerializer
+    end
+  end
+
+  describe 'serializer methods' do
+    it 'responds to serializer' do
+      expect(instance).to respond_to(:serializer)
+    end
+
+    it 'responds to all *_serializer methods defined in Factory', :aggregate_failures do
+      expect(instance).to respond_to(:chain)
+      expect(instance).to respond_to(:for_extracted)
+      expect(instance).to respond_to(:field)
+      expect(instance).to respond_to(:attribute_field)
+      expect(instance).to respond_to(:association_field)
+      expect(instance).to respond_to(:belongs_to_field)
+      expect(instance).to respond_to(:has_many_field)
+    end
+
+    it 'does not respond to non-serializer methods defined in Factory', :aggregate_failures do
+      expect(instance).not_to respond_to(:from_name_extractor)
+      expect(instance).not_to respond_to(:custom_extractor)
+      expect(instance).not_to respond_to(:association_extractor)
+      expect(instance).not_to respond_to(:belongs_to_extractor)
+      expect(instance).not_to respond_to(:has_many_extractor)
+    end
+
+    it 'does not respond to nonexistent methods' do
+      expect(instance).not_to respond_to(:nonexistent_serializer)
+    end
+
+    context 'when called' do
+      before { instance.attribute_field(:name) }
+
+      it 'delegates correctly', :aggregate_failures do
+        expect(instance.added_serializers.count).to eq 1
+        expect(instance.added_serializers.first).to be_a Porridge::FieldSerializer
+      end
+    end
+  end
+
+  describe 'field methods' do
+    it 'responds to all *_field methods defined in Factory', :aggregate_failures do
+      expect(instance).to respond_to(:attribute)
+      expect(instance).to respond_to(:association)
+      expect(instance).to respond_to(:belongs_to)
+      expect(instance).to respond_to(:has_many)
+    end
+
+    it 'does not respond to nonexistent methods', :aggregate_failures do
+      expect(instance).not_to respond_to(:nonexistent_field)
+      expect(instance).not_to respond_to(:nonexistent_field_serializer)
+    end
+
+    context 'when called' do
+      before { instance.attribute(:name) }
+
+      it 'delegates correctly', :aggregate_failures do
+        expect(instance.added_serializers.count).to eq 1
+        expect(instance.added_serializers.first).to be_a Porridge::FieldSerializer
+      end
+    end
+  end
+
+  describe '#defined_serializer' do
+    before do
+      instance.attribute(:name)
+      instance.attribute(:email)
+    end
+
+    let(:object) { Struct.new(:name, :email).new('Jacob', 'example@example.com') }
+    let(:result) { instance.defined_serializer }
+
+    it 'returns a serializer that chains all the defined ones' do
+      expect(result.call(object, {},
+                         field_policy: Porridge::FieldPolicy.new)).to eq({ name: 'Jacob',
+                                                                           email: 'example@example.com' })
+    end
+  end
+
+  describe '#call' do
+    before do
+      instance.attribute(:name)
+      instance.attribute(:email)
+    end
+
+    let(:object) { Struct.new(:name, :email).new('Jacob', 'example@example.com') }
+
+    it 'returns delegates to the defined serializer' do
+      expect(instance.call(object, {},
+                           field_policy: Porridge::FieldPolicy.new)).to eq({ name: 'Jacob',
+                                                                             email: 'example@example.com' })
+    end
+  end
+end


### PR DESCRIPTION
Write `Factory`, `SerializerDefiner`, and `SerializerDefinition` to provide an elegant DSL over the foundational classes.