### PR TITLE
Write `Factory#attribute_extractor`

### DIFF
--- a/lib/porridge/factory.rb
+++ b/lib/porridge/factory.rb
@@ -35,9 +35,13 @@ module Porridge
       extractor callback
     end
 
+    def attribute_extractor(name: nil, callback: nil, &block)
+      custom_extractor(callback || block) || from_name_extractor(name)
+    end
+
     def association_extractor(serializer:, extractor: nil, extraction_name: nil, callback: nil, &block)
       extractor SerializingExtractor.new(
-        extractor || custom_extractor(callback) || custom_extractor(block) || from_name_extractor(extraction_name),
+        extractor || attribute_extractor(name: extraction_name, callback: callback, &block),
         serializer
       )
     end
@@ -78,8 +82,7 @@ module Porridge
     end
 
     def attribute_field_serializer(name, callback = nil, extraction_name: nil, &block)
-      extractor = custom_extractor(callback || block) || from_name_extractor(extraction_name || name)
-      field_serializer(name, extractor)
+      field_serializer(name, attribute_extractor(name: extraction_name || name, callback: callback, &block))
     end
 
     def attributes_field_serializer(*names)

--- a/spec/porridge/factory_spec.rb
+++ b/spec/porridge/factory_spec.rb
@@ -68,6 +68,32 @@ describe Porridge::Factory do
     end
   end
 
+  describe '#attribute_extractor' do
+    context 'when given only name' do
+      let(:result) { instance.attribute_extractor(name: :length) }
+
+      it 'returns an extractor that sends a method to the object' do
+        expect(result.call('abcde', {})).to eq 5
+      end
+    end
+
+    context 'when given a callback' do
+      let(:result) { instance.attribute_extractor(callback: proc { |obj| obj.reverse }) }
+
+      it 'returns a serializer that adds a field via calling the callback' do
+        expect(result.call('abc', {})).to eq 'cba'
+      end
+    end
+
+    context 'when given a block' do
+      let(:result) { instance.attribute_extractor { |obj, _opts| obj.reverse } }
+
+      it 'returns a serializer that adds a field via calling the block' do
+        expect(result.call('abc', {})).to eq 'cba'
+      end
+    end
+  end
+
   shared_examples_for '#association_extractor' do
     let(:serializer) { proc { |obj| obj } }
 

--- a/spec/support/shared_examples/serializer_definer.rb
+++ b/spec/support/shared_examples/serializer_definer.rb
@@ -13,6 +13,7 @@ shared_examples_for 'SerializerDefiner' do
     it 'responds to the same ones as Factory', :aggregate_failures do
       expect(instance).to respond_to(:create_from_name_extractor)
       expect(instance).to respond_to(:create_custom_extractor)
+      expect(instance).to respond_to(:create_attribute_extractor)
       expect(instance).to respond_to(:create_association_extractor)
       expect(instance).to respond_to(:create_belongs_to_extractor)
       expect(instance).to respond_to(:create_has_many_extractor)
@@ -57,6 +58,7 @@ shared_examples_for 'SerializerDefiner' do
     it 'does not respond to non-serializer methods defined in Factory', :aggregate_failures do
       expect(instance).not_to respond_to(:from_name_extractor)
       expect(instance).not_to respond_to(:custom_extractor)
+      expect(instance).not_to respond_to(:attribute_extractor)
       expect(instance).not_to respond_to(:association_extractor)
       expect(instance).not_to respond_to(:belongs_to_extractor)
       expect(instance).not_to respond_to(:has_many_extractor)


### PR DESCRIPTION
Write and test Factory#attribute_extractor, and use it in the other Factory attribute methods. This method combines functionality from `custom_extractor` and `from_name_extractor` into one interface. Resolves #15.