### PR TITLE
Fix ArraySerializer Hash Treatment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Fixed bug where method alises in `Factory` were not respecting an overriden "source" method.
+- Fixed bug where `ArraySerializer` counted hashes as arrays.
 
 ## [0.2.2] - 2022-01-19
 

--- a/lib/porridge/array_serializer.rb
+++ b/lib/porridge/array_serializer.rb
@@ -43,7 +43,7 @@ module Porridge
     # @param object the object to check.
     # @return [Boolean] +true+ if the given object functions like an array; +false+ if otherwise.
     def array?(object)
-      object.respond_to? :map
+      object.is_a? Array
     end
 
     private

--- a/spec/porridge/array_serializer_spec.rb
+++ b/spec/porridge/array_serializer_spec.rb
@@ -32,6 +32,15 @@ describe Porridge::ArraySerializer do
       end
     end
 
+    context 'when given a hash' do
+      let(:instance) { described_class.new(proc { |obj| obj }) }
+      let(:result) { instance.call({ initial: true }, {}, {}) }
+
+      it 'does not treat it as an array' do
+        expect(result).to eq({ initial: true })
+      end
+    end
+
     context 'when given an array' do
       let(:result) { instance.call([Object.new, Object.new, Object.new], 5, {}) }
 


### PR DESCRIPTION
Fix #17 by preventing ArraySerializer from treating hashes as arrays.